### PR TITLE
Fix code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/src/monitoring/analytics_dashboard.py
+++ b/src/monitoring/analytics_dashboard.py
@@ -14,4 +14,6 @@ def analytics():
     return jsonify(data)
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    import os
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Fixes [https://github.com/rfc391/HyCAN/security/code-scanning/1](https://github.com/rfc391/HyCAN/security/code-scanning/1)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, the application can run in debug mode during development but will have debugging disabled in production.

1. Modify the `app.run(debug=True)` line to check an environment variable to determine whether to enable debug mode.
2. Import the `os` module to access environment variables.
3. Set a default value for the environment variable to ensure the application does not run in debug mode by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
